### PR TITLE
Change memoization decorator function

### DIFF
--- a/evident/diversity_handler.py
+++ b/evident/diversity_handler.py
@@ -31,7 +31,7 @@ class BaseDiversityHandler(ABC):
         return self.metadata.index.to_list()
 
     # Memoize this function for repeated calls
-    @lru_cache
+    @lru_cache()
     def calculate_effect_size(
         self,
         column: str,


### PR DESCRIPTION
Apparently decorating a function with `@lru_cache` is only allowed on Python 3.8+. Changing to `@lru_cache()` which I hope should solve the problem.