### PR TITLE
Add code for getting effect size from multiple categories

### DIFF
--- a/evident/exploration.py
+++ b/evident/exploration.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from evident.diversity_handler import _BaseDiversityHandler
+
+
+def effect_size_by_category(
+    diversity_handler: _BaseDiversityHandler,
+    columns: list = None
+):
+    dh = diversity_handler
+    effect_size_dict = dict()
+    for col in columns:
+        num_choices = len(dh.metadata[col].unique())
+        effect_size = dh.calculate_effect_size(col)
+        if num_choices == 2:
+            metric = "cohens_d"
+        else:
+            metric = "cohens_f"
+        effect_size_dict[col] = {"metric": metric, "value": effect_size}
+
+    return pd.DataFrame.from_dict(effect_size_dict, orient="index")

--- a/evident/exploration.py
+++ b/evident/exploration.py
@@ -1,14 +1,35 @@
+from itertools import combinations
+
 import pandas as pd
 
 from evident.diversity_handler import _BaseDiversityHandler
+from evident.stats import calculate_cohens_d
 
 
 def effect_size_by_category(
     diversity_handler: _BaseDiversityHandler,
-    columns: list = None
-):
+    columns: list = None,
+) -> pd.DataFrame:
+    """Compute effect size for a set of columns.
+
+    Output DataFrame has as index the argument columns. DataFrame columns are
+    'metric' and 'value'. Metric is either 'cohens_d' or 'cohens_f' if the
+    given category has 2 or more than 2 levels, respectively. 'value' has the
+    numeric effect size. Sorts output first by Cohen's d -> f and then effect
+    size in decreasing order.
+
+    :param diversity_handler: Either an alpha or beta DiversityHandler
+    :type diversity_handler: evident.diversity_handler._BaseDiversityHandler
+
+    :param columns: Columns to use for effect size calculations
+    :type columns: List[str]
+
+    :returns: DataFrame of effect size per category
+    :rtype: pd.DataFrame
+    """
     dh = diversity_handler
     effect_size_dict = dict()
+
     for col in columns:
         num_choices = len(dh.metadata[col].unique())
         effect_size = dh.calculate_effect_size(col)
@@ -18,4 +39,53 @@ def effect_size_by_category(
             metric = "cohens_f"
         effect_size_dict[col] = {"metric": metric, "value": effect_size}
 
-    return pd.DataFrame.from_dict(effect_size_dict, orient="index")
+    # Sort by metric first (d -> f) then value in descending order
+    effect_size_df = pd.DataFrame.from_dict(effect_size_dict, orient="index")
+    effect_size_df = effect_size_df.sort_values(by=["metric", "value"],
+                                                ascending=[True, False])
+    return effect_size_df
+
+
+def pairwise_effect_size_by_category(
+    diversity_handler: _BaseDiversityHandler,
+    columns: list = None
+) -> pd.DataFrame:
+    """Compute effect size for a set of columns using pairwise comparisons.
+
+    Output DataFrame has no index. DataFrame columns are 'column', 'group_1',
+    'group_2', and 'cohens_d'. 'column' has the column from which each row's
+    pairwise comparison arises. 'group_1' has the first level of the category
+    in 'column' while 'group_2' has the second level of the category in
+    'column'. 'cohens_d' has the effect size of each comparison. Output is
+    sorted by decreasing 'cohens_d'.
+
+    :param diversity_handler: Either an alpha or beta DiversityHandler
+    :type diversity_handler: evident.diversity_handler._BaseDiversityHandler
+
+    :param columns: Columns to use for effect size calculations
+    :type columns: List[str]
+
+    :returns: DataFrame of effect size per pairwise comparison
+    :rtype: pd.DataFrame
+    """
+    dh = diversity_handler
+    effect_size_records = []
+
+    for col in columns:
+        values_dict = dict()
+
+        # Get all index sets here to avoid redundant computation
+        grp_dfs = (dh.metadata .groupby(col))
+        for grp, _df in grp_dfs:
+            values_dict[grp] = dh.subset_values(_df.index)
+
+        for grp1, grp2 in combinations(values_dict.keys(), 2):
+            vals1 = values_dict[grp1]
+            vals2 = values_dict[grp2]
+            effect_size = calculate_cohens_d(vals1, vals2)
+            effect_size_records.append((col, grp1, grp2, effect_size))
+
+    effect_size_df = pd.DataFrame.from_records(effect_size_records)
+    effect_size_df.columns = ["column", "group_1", "group_2", "cohens_d"]
+
+    return effect_size_df.sort_values(by="cohens_d", ascending=False)

--- a/evident/exploration.py
+++ b/evident/exploration.py
@@ -27,6 +27,7 @@ def effect_size_by_category(
     :returns: DataFrame of effect size per category
     :rtype: pd.DataFrame
     """
+    _check_columns(columns)
     dh = diversity_handler
     effect_size_dict = dict()
 
@@ -68,6 +69,7 @@ def pairwise_effect_size_by_category(
     :returns: DataFrame of effect size per pairwise comparison
     :rtype: pd.DataFrame
     """
+    _check_columns(columns)
     dh = diversity_handler
     effect_size_records = []
 
@@ -89,3 +91,9 @@ def pairwise_effect_size_by_category(
     effect_size_df.columns = ["column", "group_1", "group_2", "cohens_d"]
 
     return effect_size_df.sort_values(by="cohens_d", ascending=False)
+
+
+def _check_columns(columns) -> None:
+    """Check to make sure a list of columns has been passed."""
+    if columns is None:
+        raise ValueError("Must provide list of columns!")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+
+import pandas as pd
+import pytest
+from skbio import DistanceMatrix
+
+from evident.diversity_handler import (AlphaDiversityHandler,
+                                       BetaDiversityHandler)
+
+
+# Access these with https://stackoverflow.com/a/64348247
+@pytest.fixture
+def alpha_mock():
+    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
+    df = pd.read_table(fname, sep="\t", index_col=0)
+    adh = AlphaDiversityHandler(df["faith_pd"], df)
+    return adh
+
+
+@pytest.fixture
+def beta_mock():
+    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
+    df = pd.read_table(fname, sep="\t", index_col=0)
+    dm_file = os.path.join(os.path.dirname(__file__),
+                           "data/distance_matrix.lsmat.gz")
+    dm = DistanceMatrix.read(dm_file)
+    bdh = BetaDiversityHandler(dm, df)
+    return bdh

--- a/tests/test_diversity_handler.py
+++ b/tests/test_diversity_handler.py
@@ -10,25 +10,6 @@ from evident.diversity_handler import (AlphaDiversityHandler,
 import evident.exceptions as exc
 
 
-@pytest.fixture
-def alpha_mock():
-    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
-    df = pd.read_table(fname, sep="\t", index_col=0)
-    adh = AlphaDiversityHandler(df["faith_pd"], df)
-    return adh
-
-
-@pytest.fixture
-def beta_mock():
-    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
-    df = pd.read_table(fname, sep="\t", index_col=0)
-    dm_file = os.path.join(os.path.dirname(__file__),
-                           "data/distance_matrix.lsmat.gz")
-    dm = DistanceMatrix.read(dm_file)
-    bdh = BetaDiversityHandler(dm, df)
-    return bdh
-
-
 class TestAlphaDiv:
     def test_init_alpha_div_handler(self):
         fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -15,6 +15,9 @@ def test_effect_size_by_cat():
         adh, columns=["perianal_disease", "sex", "classification",
                       "cd_behavior"]
     )
+
+    assert ~df.isna().any().any()
+
     exp_index = {"perianal_disease", "sex", "classification",
                  "cd_behavior"}
     assert set(df.index) == exp_index
@@ -37,6 +40,8 @@ def test_pairwise_effect_size_by_cat():
         adh, columns=["perianal_disease", "sex", "classification",
                       "cd_behavior"]
     )
+
+    assert ~df.isna().any().any()
 
     exp_cols = ["column", "group_1", "group_2", "cohens_d"]
     assert (df.columns == exp_cols).all()

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -15,12 +15,48 @@ def test_effect_size_by_cat():
         adh, columns=["perianal_disease", "sex", "classification",
                       "cd_behavior"]
     )
-    exp_index = ["perianal_disease", "sex", "classification",
-                 "cd_behavior"]
-    assert (df.index == exp_index).all()
+    exp_index = {"perianal_disease", "sex", "classification",
+                 "cd_behavior"}
+    assert set(df.index) == exp_index
 
     exp_cols = ["metric", "value"]
     assert (df.columns == exp_cols).all()
 
-    exp_metrics = ["cohens_d", "cohens_d", "cohens_d", "cohens_f"]
-    assert (df["metric"] == exp_metrics).all()
+    assert df.loc["perianal_disease"]["metric"] == "cohens_d"
+    assert df.loc["sex"]["metric"] == "cohens_d"
+    assert df.loc["classification"]["metric"] == "cohens_d"
+    assert df.loc["cd_behavior"]["metric"] == "cohens_f"
+
+
+def test_pairwise_effect_size_by_cat():
+    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
+    df = pd.read_table(fname, sep="\t", index_col=0)
+    adh = AlphaDiversityHandler(df["faith_pd"], df)
+
+    df = expl.pairwise_effect_size_by_category(
+        adh, columns=["perianal_disease", "sex", "classification",
+                      "cd_behavior"]
+    )
+
+    exp_cols = ["column", "group_1", "group_2", "cohens_d"]
+    assert (df.columns == exp_cols).all()
+
+    all_grp_counts = df["column"].value_counts()
+    assert all_grp_counts.loc["classification"] == 1
+    assert all_grp_counts.loc["perianal_disease"] == 1
+    assert all_grp_counts.loc["sex"] == 1
+
+    cd_behavior_df = df.query("column == 'cd_behavior'")
+    assert cd_behavior_df.shape == (3, 4)
+
+    cd_behavior_melt_df = cd_behavior_df.melt(
+        value_vars=["group_1", "group_2"]
+    )
+    grp_counts = cd_behavior_melt_df["value"].value_counts()
+    grps = [
+        "Non-stricturing, non-penetrating (B1)",
+        "Stricturing (B2)",
+        "Penetrating (B3)"
+    ]
+    for grp in grps:
+        assert grp_counts.loc[grp] == 2

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -1,0 +1,26 @@
+import os
+
+import pandas as pd
+
+from evident import AlphaDiversityHandler
+from evident import exploration as expl
+
+
+def test_effect_size_by_cat():
+    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
+    df = pd.read_table(fname, sep="\t", index_col=0)
+    adh = AlphaDiversityHandler(df["faith_pd"], df)
+
+    df = expl.effect_size_by_category(
+        adh, columns=["perianal_disease", "sex", "classification",
+                      "cd_behavior"]
+    )
+    exp_index = ["perianal_disease", "sex", "classification",
+                 "cd_behavior"]
+    assert (df.index == exp_index).all()
+
+    exp_cols = ["metric", "value"]
+    assert (df.columns == exp_cols).all()
+
+    exp_metrics = ["cohens_d", "cohens_d", "cohens_d", "cohens_f"]
+    assert (df["metric"] == exp_metrics).all()

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+import pytest
 
 from evident import AlphaDiversityHandler
 from evident import exploration as expl
@@ -65,3 +66,18 @@ def test_pairwise_effect_size_by_cat():
     ]
     for grp in grps:
         assert grp_counts.loc[grp] == 2
+
+
+def test_no_cols():
+    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
+    df = pd.read_table(fname, sep="\t", index_col=0)
+    adh = AlphaDiversityHandler(df["faith_pd"], df)
+
+    with pytest.raises(ValueError) as exc_info_1:
+        expl.effect_size_by_category(adh)
+
+    with pytest.raises(ValueError) as exc_info_2:
+        expl.pairwise_effect_size_by_category(adh)
+
+    exp_err_msg = "Must provide list of columns!"
+    assert str(exc_info_1.value) == str(exc_info_2.value) == exp_err_msg

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -1,20 +1,14 @@
-import os
-
-import pandas as pd
 import pytest
 
-from evident import AlphaDiversityHandler
 from evident import exploration as expl
 
 
-def test_effect_size_by_cat():
-    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
-    df = pd.read_table(fname, sep="\t", index_col=0)
-    adh = AlphaDiversityHandler(df["faith_pd"], df)
-
+@pytest.mark.parametrize("mock", ["alpha_mock", "beta_mock"])
+def test_effect_size_by_cat(mock, request):
+    dh = request.getfixturevalue(mock)
     df = expl.effect_size_by_category(
-        adh, columns=["perianal_disease", "sex", "classification",
-                      "cd_behavior"]
+        dh, columns=["perianal_disease", "sex", "classification",
+                     "cd_behavior"]
     )
 
     assert ~df.isna().any().any()
@@ -32,14 +26,12 @@ def test_effect_size_by_cat():
     assert df.loc["cd_behavior"]["metric"] == "cohens_f"
 
 
-def test_pairwise_effect_size_by_cat():
-    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
-    df = pd.read_table(fname, sep="\t", index_col=0)
-    adh = AlphaDiversityHandler(df["faith_pd"], df)
-
+@pytest.mark.parametrize("mock", ["alpha_mock", "beta_mock"])
+def test_pairwise_effect_size_by_cat(mock, request):
+    dh = request.getfixturevalue(mock)
     df = expl.pairwise_effect_size_by_category(
-        adh, columns=["perianal_disease", "sex", "classification",
-                      "cd_behavior"]
+        dh, columns=["perianal_disease", "sex", "classification",
+                     "cd_behavior"]
     )
 
     assert ~df.isna().any().any()
@@ -68,16 +60,15 @@ def test_pairwise_effect_size_by_cat():
         assert grp_counts.loc[grp] == 2
 
 
-def test_no_cols():
-    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
-    df = pd.read_table(fname, sep="\t", index_col=0)
-    adh = AlphaDiversityHandler(df["faith_pd"], df)
+@pytest.mark.parametrize("mock", ["alpha_mock", "beta_mock"])
+def test_no_cols(mock, request):
+    dh = request.getfixturevalue(mock)
 
     with pytest.raises(ValueError) as exc_info_1:
-        expl.effect_size_by_category(adh)
+        expl.effect_size_by_category(dh)
 
     with pytest.raises(ValueError) as exc_info_2:
-        expl.pairwise_effect_size_by_category(adh)
+        expl.pairwise_effect_size_by_category(dh)
 
     exp_err_msg = "Must provide list of columns!"
     assert str(exc_info_1.value) == str(exc_info_2.value) == exp_err_msg

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,16 +1,12 @@
-import os
+import pytest
 
-import pandas as pd
-
-from evident.diversity_handler import AlphaDiversityHandler
 from evident.plotting import plot_power_curve
 
 
-def test_plot_power_curve():
-    fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
-    df = pd.read_table(fname, sep="\t", index_col=0)
-    a = AlphaDiversityHandler(df["faith_pd"], df)
+@pytest.mark.parametrize("mock", ["alpha_mock", "beta_mock"])
+def test_plot_power_curve(mock, request):
+    dh = request.getfixturevalue(mock)
 
     alpha = [0.01, 0.05, 0.1]
-    res = a.power_analysis(column="classification", alpha=alpha, power=0.8)
+    res = dh.power_analysis(column="classification", alpha=alpha, power=0.8)
     plot_power_curve(res)


### PR DESCRIPTION
Similar to the behavior of the previous version of evident. Allows the user to pass in a list of columns and calculates the effect size for each one in the context of the given diversity file. Also allows for pairwise comparisons.

Also modifies test suite to store fixtures in `conftest.py` that can be accessed easier from different testing files.