### PR TITLE
Restructure level limits in DiversityHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ The main data structure in evident is the 'DiversityHandler'.
 This is the way that evident stores the diversity data and metadata for power calculations.
 For our alpha diversity example, we'll load the `AlphaDiversityHandler` class from evident.
 `AlphaDiversityHandler` takes as input the pandas Series with the diversity values and the pandas DataFrame containing the sample metadata.
+By default, evident will only consider metadata columns with, at max, 5 levels.
+To modify this behavior, provide a value for the `max_levels_per_category` argument.
+Additionally, evident will not consider any category levels represented by fewer than 3 samples.
+To modify this behavior, use the `min_count_per_level` argument.
 
 ```python
 adh = evident.AlphaDiversityHandler(faith_pd, metadata)
@@ -158,10 +162,6 @@ bokeh serve --show app
 ```
 
 This should open up a browser window where you can modify the chosen column, significance, level, and observations.
-By default, this interactive view will only consider metadata columns with, at max, 5 levels.
-To modify this behavior, use the `max_levels_per_category` argument in `create_bokeh_app`.
-Additionally, this interactive view will not consider any category levels represented by fewer than 3 samples.
-To modify this behavior, use the `min_count_per_level` argument.
 We also provide a command line script to generate an interactive app using some test data.
 You can access this script at `evident/tests/make_interactive.py`.
 

--- a/evident/diversity_handler.py
+++ b/evident/diversity_handler.py
@@ -49,6 +49,7 @@ class _BaseDiversityHandler(ABC):
 
             # Drop levels that have fewer than min_count_per_level samples
             level_count = metadata[col].value_counts()
+            print(col, level_count, min_count_per_level)
             under_thresh = level_count[level_count < min_count_per_level]
             if not under_thresh.empty:
                 levels_under_thresh = list(under_thresh.index)
@@ -401,7 +402,9 @@ class AlphaDiversityHandler(_BaseDiversityHandler):
 
         super().__init__(
             data=data.loc[samps_in_common],
-            metadata=metadata.loc[samps_in_common]
+            metadata=metadata.loc[samps_in_common],
+            max_levels_per_category=max_levels_per_category,
+            min_count_per_level=min_count_per_level
         )
 
     def subset_values(self, ids: list) -> np.array:
@@ -444,7 +447,9 @@ class BetaDiversityHandler(_BaseDiversityHandler):
 
         super().__init__(
             data=data.filter(samps_in_common),
-            metadata=metadata.loc[samps_in_common]
+            metadata=metadata.loc[samps_in_common],
+            max_levels_per_category=max_levels_per_category,
+            min_count_per_level=min_count_per_level
         )
 
     def subset_values(self, ids: list) -> np.array:

--- a/evident/diversity_handler.py
+++ b/evident/diversity_handler.py
@@ -221,7 +221,7 @@ class _BaseDiversityHandler(ABC):
         :type power: float
 
         :returns: Collection of values from power analysis
-        :rtype: evident.power.PowerAnalysisResult
+        :rtype: evident.results.PowerAnalysisResult
         """
         power_func = self._create_partial_power_func(
             column=column,
@@ -288,7 +288,7 @@ class _BaseDiversityHandler(ABC):
         :type power: sequence of floats
 
         :returns: Collection of values from power analyses
-        :rtype: evident.power.PowerAnalysisResults
+        :rtype: evident.results.PowerAnalysisResults
         """
         # Convert all to list so we can use Cartesian product
         difference = _listify(difference)

--- a/evident/diversity_handler.py
+++ b/evident/diversity_handler.py
@@ -49,7 +49,6 @@ class _BaseDiversityHandler(ABC):
 
             # Drop levels that have fewer than min_count_per_level samples
             level_count = metadata[col].value_counts()
-            print(col, level_count, min_count_per_level)
             under_thresh = level_count[level_count < min_count_per_level]
             if not under_thresh.empty:
                 levels_under_thresh = list(under_thresh.index)

--- a/evident/diversity_handler.py
+++ b/evident/diversity_handler.py
@@ -62,8 +62,8 @@ class _BaseDiversityHandler(ABC):
 
         if warn_msg_num_levels:
             warn(
-                "Some categories have been dropped because they had either only "
-                "one level or too many. Use the max_levels_per_category "
+                "Some categories have been dropped because they had either "
+                "only one level or too many. Use the max_levels_per_category "
                 "argument to modify this threshold.\n"
                 f"Dropped columns: {cols_to_drop}"
             )

--- a/evident/diversity_handler.py
+++ b/evident/diversity_handler.py
@@ -373,8 +373,8 @@ class AlphaDiversityHandler(_BaseDiversityHandler):
     ):
         """Handler for alpha diversity data.
 
-        :param data: Beta diversity distance matrix
-        :type data: skbio.DistanceMatrix
+        :param data: Alpha diversity vector
+        :type data: pd.Series
 
         :param metadata: Sample metadata
         :type metadata: pd.DataFrame

--- a/evident/diversity_handler.py
+++ b/evident/diversity_handler.py
@@ -19,9 +19,62 @@ from .utils import _listify, _check_sample_overlap
 
 class _BaseDiversityHandler(ABC):
     """Abstract class for handling diversity data and metadata."""
-    def __init__(self, data=None, metadata: pd.DataFrame = None):
+    def __init__(
+        self,
+        data=None,
+        metadata: pd.DataFrame = None,
+        max_levels_per_category: int = 5,
+        min_count_per_level: int = 3
+    ):
         self.data = data
-        self.metadata = metadata
+        metadata = metadata.copy()
+
+        cols_to_drop = []
+        levels_to_drop = dict()
+
+        warn_msg_num_levels = False
+        warn_msg_level_count = False
+        for col in metadata.columns:
+            # Drop non-categorical columns
+            if metadata[col].dtype != np.dtype("object"):
+                cols_to_drop.append(col)
+                continue
+
+            # Drop columns with only one level or more than max
+            num_uniq_cols = len(metadata[col].dropna().unique())
+            if not (1 < num_uniq_cols <= max_levels_per_category):
+                cols_to_drop.append(col)
+                warn_msg_num_levels = True
+                continue
+
+            # Drop levels that have fewer than min_count_per_level samples
+            level_count = metadata[col].value_counts()
+            under_thresh = level_count[level_count < min_count_per_level]
+            if not under_thresh.empty:
+                levels_under_thresh = list(under_thresh.index)
+                metadata[col].replace(
+                    {x: np.nan for x in levels_under_thresh},
+                    inplace=True
+                )
+                levels_to_drop[col] = levels_under_thresh
+                warn_msg_level_count = True
+
+        if warn_msg_num_levels:
+            warn(
+                "Some categories have been dropped because they had either only "
+                "one level or too many. Use the max_levels_per_category "
+                "argument to modify this threshold.\n"
+                f"Dropped columns: {cols_to_drop}"
+            )
+        if warn_msg_level_count:
+            warn(
+                "Some categorical levels have been dropped because they "
+                "did not have enough samples. Use the min_count_per_level "
+                "argument to modify this threshold.\n"
+                f"Dropped levels: {levels_to_drop}"
+            )
+
+        self.metadata = metadata.drop(columns=cols_to_drop)
 
     @property
     def samples(self):
@@ -311,12 +364,31 @@ class _BaseDiversityHandler(ABC):
 
 
 class AlphaDiversityHandler(_BaseDiversityHandler):
-    """Handler for alpha diversity data."""
     def __init__(
         self,
         data: pd.Series,
-        metadata: pd.DataFrame
+        metadata: pd.DataFrame,
+        max_levels_per_category: int = 5,
+        min_count_per_level: int = 3
     ):
+        """Handler for alpha diversity data.
+
+        :param data: Beta diversity distance matrix
+        :type data: skbio.DistanceMatrix
+
+        :param metadata: Sample metadata
+        :type metadata: pd.DataFrame
+
+        :param max_levels_per_category: Max number of levels in a category to
+            keep. Any categorical columns that have more than this number of
+            unique levels will not be saved, defaults to 5.
+        :type max_levels_per_category: int
+
+        :param min_count_per_level: Min number of samples in a given category
+            level to keep. Any levels that have fewer than this many samples
+            will not be saved, defaults to 3.
+        :type min_count_per_level: int
+        """
         if not isinstance(data, pd.Series):
             raise ValueError("data must be of type pandas.Series")
         if data.isna().any():
@@ -338,12 +410,31 @@ class AlphaDiversityHandler(_BaseDiversityHandler):
 
 
 class BetaDiversityHandler(_BaseDiversityHandler):
-    """Handler for beta diversity data."""
     def __init__(
         self,
         data: DistanceMatrix,
-        metadata: pd.DataFrame
+        metadata: pd.DataFrame,
+        max_levels_per_category: int = 5,
+        min_count_per_level: int = 3
     ):
+        """Handler for beta diversity data.
+
+        :param data: Beta diversity distance matrix
+        :type data: skbio.DistanceMatrix
+
+        :param metadata: Sample metadata
+        :type metadata: pd.DataFrame
+
+        :param max_levels_per_category: Max number of levels in a category to
+            keep. Any categorical columns that have more than this number of
+            unique levels will not be saved, defaults to 5.
+        :type max_levels_per_category: int
+
+        :param min_count_per_level: Min number of samples in a given category
+            level to keep. Any levels that have fewer than this many samples
+            will not be saved, defaults to 3.
+        :type min_count_per_level: int
+        """
         if not isinstance(data, DistanceMatrix):
             raise ValueError("data must be of type skbio.DistanceMatrix")
 

--- a/evident/interactive.py
+++ b/evident/interactive.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-from warnings import warn
 
 from evident.diversity_handler import (_BaseDiversityHandler,
                                        AlphaDiversityHandler,

--- a/evident/interactive.py
+++ b/evident/interactive.py
@@ -2,8 +2,6 @@ import os
 import shutil
 from warnings import warn
 
-import numpy as np
-
 from evident.diversity_handler import (_BaseDiversityHandler,
                                        AlphaDiversityHandler,
                                        BetaDiversityHandler)
@@ -12,8 +10,6 @@ from evident.diversity_handler import (_BaseDiversityHandler,
 def create_bokeh_app(
     diversity_handler: _BaseDiversityHandler,
     output: os.PathLike,
-    max_levels_per_category: int = 5,
-    min_count_per_level: int = 3
 ) -> None:
     """Creates interactive power analysis using Bokeh.
 
@@ -22,15 +18,6 @@ def create_bokeh_app(
 
     :param output: Location to create Bokeh app
     :type output: os.PathLike
-
-    :param max_levels_per_category: Max number of levels in a category to
-        keep. Any categorical columns that have more than this number of
-        unique levels will not be saved, defaults to 5.
-    :type max_levels_per_category: int
-
-    :param min_count_per_level: Min number of samples in a given category
-        level to keep. Any levels that have fewer than this many samples
-        will not be saved, defaults = 3.
     """
     curr_path = os.path.dirname(__file__)
     support_files = os.path.join(curr_path, "support_files")
@@ -40,49 +27,9 @@ def create_bokeh_app(
     data_dir = os.path.join(output, "data")
     os.mkdir(data_dir)
 
-    # Process metadata
     md = diversity_handler.metadata.copy()
-    cols_to_drop = []
-    warn_msg_num_levels = False
-    warn_msg_level_count = False
-    for col in md.columns:
-        # Drop non-categorical columns
-        if md[col].dtype != np.dtype("object"):
-            cols_to_drop.append(col)
-            continue
-
-        # Drop columns with only one level or more than max
-        if not (1 < len(md[col].dropna().unique()) <= max_levels_per_category):
-            cols_to_drop.append(col)
-            warn_msg_num_levels = True
-            continue
-
-        # Drop levels that have fewer than min_count_per_level samples
-        level_count = md[col].value_counts()
-        under_thresh = level_count[level_count < min_count_per_level]
-        if not under_thresh.empty:
-            levels_under_thresh = list(under_thresh.index)
-            md[col].replace(
-                {x: np.nan for x in levels_under_thresh},
-                inplace=True
-            )
-            warn_msg_level_count = True
-
-    if warn_msg_num_levels:
-        warn(
-            "Some categories have been dropped because they had either only "
-            "one level or too many. Use the max_levels_per_category "
-            "argument to modify this threshold."
-        )
-    if warn_msg_level_count:
-        warn(
-            "Some categorical levels have been dropped because they "
-            "did not have enough samples. Use the min_count_per_level "
-            "argument to modify this threshold."
-        )
-
     md_loc = os.path.join(data_dir, "metadata.tsv")
-    md.drop(columns=cols_to_drop).to_csv(md_loc, sep="\t", index=True)
+    md.to_csv(md_loc, sep="\t", index=True)
 
     data = diversity_handler.data
     if isinstance(diversity_handler, AlphaDiversityHandler):

--- a/evident/q2/_methods.py
+++ b/evident/q2/_methods.py
@@ -12,13 +12,17 @@ from evident.effect_size import (effect_size_by_category,
 def alpha_power_analysis(
     alpha_diversity: pd.Series,
     sample_metadata: CategoricalMetadataColumn,
+    max_levels_per_category: int = 5,
+    min_count_per_level: int = 3,
     alpha: list = None,
     power: list = None,
     total_observations: list = None,
-    difference: list = None
+    difference: list = None,
 ) -> pd.DataFrame:
     res = _power_analysis(alpha_diversity, sample_metadata,
-                          AlphaDiversityHandler, alpha=alpha, power=power,
+                          AlphaDiversityHandler,
+                          max_levels_per_category, min_count_per_level,
+                          alpha=alpha, power=power,
                           total_observations=total_observations,
                           difference=difference)
     return res
@@ -27,22 +31,28 @@ def alpha_power_analysis(
 def beta_power_analysis(
     beta_diversity: DistanceMatrix,
     sample_metadata: CategoricalMetadataColumn,
+    max_levels_per_category: int = 5,
+    min_count_per_level: int = 3,
     alpha: list = None,
     power: list = None,
     total_observations: list = None,
-    difference: list = None
+    difference: list = None,
 ) -> pd.DataFrame:
     res = _power_analysis(beta_diversity, sample_metadata,
-                          BetaDiversityHandler, alpha=alpha, power=power,
+                          BetaDiversityHandler,
+                          max_levels_per_category, min_count_per_level,
+                          alpha=alpha, power=power,
                           total_observations=total_observations,
                           difference=difference)
     return res
 
 
-def _power_analysis(data, metadata, handler, **kwargs):
+def _power_analysis(data, metadata, handler, max_levels_per_category,
+                    min_count_per_level, **kwargs):
     md = metadata.to_series()
     column = md.name
-    dh = handler(data, md.to_frame())
+    dh = handler(data, md.to_frame(), max_levels_per_category,
+                 min_count_per_level)
     res = dh.power_analysis(column, **kwargs)
     return res.to_dataframe()
 
@@ -52,11 +62,14 @@ def alpha_effect_size_by_category(
     sample_metadata: Metadata,
     columns: List[str],
     pairwise: bool = False,
-    n_jobs: int = None
+    n_jobs: int = None,
+    max_levels_per_category: int = 5,
+    min_count_per_level: int = 3
 ) -> pd.DataFrame:
     res = _effect_size_by_category(alpha_diversity, sample_metadata,
                                    AlphaDiversityHandler, columns, pairwise,
-                                   n_jobs)
+                                   n_jobs, max_levels_per_category,
+                                   min_count_per_level)
     return res
 
 
@@ -65,17 +78,22 @@ def beta_effect_size_by_category(
     sample_metadata: Metadata,
     columns: List[str],
     pairwise: bool = False,
-    n_jobs: int = None
+    n_jobs: int = None,
+    max_levels_per_category: int = 5,
+    min_count_per_level: int = 3
 ) -> pd.DataFrame:
     res = _effect_size_by_category(beta_diversity, sample_metadata,
                                    BetaDiversityHandler, columns, pairwise,
-                                   n_jobs)
+                                   n_jobs, max_levels_per_category,
+                                   min_count_per_level)
     return res
 
 
 def _effect_size_by_category(data, metadata, handler, columns, pairwise,
-                             n_jobs):
-    dh = handler(data, metadata.to_dataframe())
+                             n_jobs, max_levels_per_category,
+                             min_count_per_level):
+    dh = handler(data, metadata.to_dataframe(), max_levels_per_category,
+                 min_count_per_level)
     if pairwise:
         res = pairwise_effect_size_by_category(dh, columns, n_jobs=n_jobs)
     else:

--- a/evident/q2/plugin_setup.py
+++ b/evident/q2/plugin_setup.py
@@ -35,6 +35,16 @@ PA_PARAM_DESCS = {
         "difference. The pooled standard deviation of the groups will still "
         "be used. If not provided, evident will calculate the difference in "
         "means automatically."
+    ),
+    "max_levels_per_category": (
+        "Max number of levels in a category to keep. Any categorical columns "
+        "that have more than this number of unique levels will not be saved, "
+        "defaults to 5."
+    ),
+    "min_count_per_level": (
+        "Min number of samples in a given category level to keep. Any levels "
+        "that have fewer than this many samples will not be saved, defaults "
+        "to 3."
     )
 }
 
@@ -49,6 +59,16 @@ ES_PARAM_DESCS = {
     ),
     "n_jobs": (
         "Number of jobs to run in parallel, defaults to no parallelization."
+    ),
+    "max_levels_per_category": (
+        "Max number of levels in a category to keep. Any categorical columns "
+        "that have more than this number of unique levels will not be saved, "
+        "defaults to 5."
+    ),
+    "min_count_per_level": (
+        "Min number of samples in a given category level to keep. Any levels "
+        "that have fewer than this many samples will not be saved, defaults "
+        "to 3."
     )
 }
 
@@ -78,7 +98,9 @@ plugin.methods.register_function(
         "alpha": List[Probability],
         "power": List[Probability],
         "total_observations": List[Int],
-        "difference": List[Float]
+        "difference": List[Float],
+        "max_levels_per_category": Int,
+        "min_count_per_level": Int
     },
     parameter_descriptions=PA_PARAM_DESCS,
     outputs=[("power_analysis_results", PowerAnalysisResults)],
@@ -99,7 +121,9 @@ plugin.methods.register_function(
         "alpha": List[Probability],
         "power": List[Probability],
         "total_observations": List[Int],
-        "difference": List[Float]
+        "difference": List[Float],
+        "max_levels_per_category": Int,
+        "min_count_per_level": Int
     },
     parameter_descriptions=PA_PARAM_DESCS,
     outputs=[("power_analysis_results", PowerAnalysisResults)],
@@ -118,7 +142,9 @@ plugin.methods.register_function(
         "sample_metadata": Metadata,
         "columns": List[Str],
         "pairwise": Bool,
-        "n_jobs": Int
+        "n_jobs": Int,
+        "max_levels_per_category": Int,
+        "min_count_per_level": Int
     },
     parameter_descriptions=ES_PARAM_DESCS,
     outputs=[("effect_size_results", EffectSizeResults)],
@@ -137,7 +163,9 @@ plugin.methods.register_function(
         "sample_metadata": Metadata,
         "columns": List[Str],
         "pairwise": Bool,
-        "n_jobs": Int
+        "n_jobs": Int,
+        "max_levels_per_category": Int,
+        "min_count_per_level": Int
     },
     parameter_descriptions=ES_PARAM_DESCS,
     outputs=[("effect_size_results", EffectSizeResults)],

--- a/evident/results.py
+++ b/evident/results.py
@@ -87,10 +87,7 @@ class PowerAnalysisResults(_EvidentResults):
         records = []
         for res in self.results:
             this_res_dict = res.to_dict()
-            this_effect_size_result = (
-                this_res_dict["effect_size"]
-                .to_dict()
-            )
+            this_effect_size_result = this_res_dict["effect_size"].to_dict()
             this_res_dict.update(this_effect_size_result)
             records.append(this_res_dict)
 
@@ -104,7 +101,7 @@ class EffectSizeResults(_EvidentResults):
     def to_dataframe(sort: bool = True):
         df = super().to_dataframe()
         if sort:
-            df = df .sort_values(by=["metric", "effect_size"],
-                                 ascending=[True, False])
+            df = df.sort_values(by=["metric", "effect_size"],
+                                ascending=[True, False])
 
         return df.reset_index(drop=True)

--- a/evident/tests/test_diversity_handler.py
+++ b/evident/tests/test_diversity_handler.py
@@ -11,6 +11,7 @@ import evident._exceptions as exc
 
 na_values = ["not applicable"]
 
+
 class TestAlphaDiv:
     def test_init_alpha_div_handler(self):
         fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")

--- a/evident/tests/test_diversity_handler.py
+++ b/evident/tests/test_diversity_handler.py
@@ -9,13 +9,18 @@ from evident.diversity_handler import (AlphaDiversityHandler,
                                        BetaDiversityHandler)
 import evident._exceptions as exc
 
+na_values = ["not applicable"]
 
 class TestAlphaDiv:
     def test_init_alpha_div_handler(self):
         fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
-        df = pd.read_table(fname, sep="\t", index_col=0)
+        df = pd.read_table(fname, sep="\t", index_col=0, na_values=na_values)
+        exp_cols = [
+            "cd_behavior", "cd_location", "cd_resection", "ibd_subtype",
+            "perianal_disease", "sex", "classification"
+        ]
         a = AlphaDiversityHandler(df["faith_pd"], df)
-        assert a.metadata.shape == (220, 40)
+        assert a.metadata.shape == (220, len(exp_cols))
         assert a.data.shape == (220, )
 
     def test_subset_alpha_values(self, alpha_mock):
@@ -61,12 +66,16 @@ class TestAlphaDiv:
 class TestBetaDiv:
     def test_init_beta_div_handler(self):
         fname = os.path.join(os.path.dirname(__file__), "data/metadata.tsv")
-        df = pd.read_table(fname, sep="\t", index_col=0)
+        df = pd.read_table(fname, sep="\t", index_col=0, na_values=na_values)
+        exp_cols = [
+            "cd_behavior", "cd_location", "cd_resection", "ibd_subtype",
+            "perianal_disease", "sex", "classification"
+        ]
         dm_file = os.path.join(os.path.dirname(__file__),
                                "data/distance_matrix.lsmat.gz")
         dm = DistanceMatrix.read(dm_file)
         b = BetaDiversityHandler(dm, df)
-        assert b.metadata.shape == (220, 40)
+        assert b.metadata.shape == (220, len(exp_cols))
         assert b.data.shape == (220, 220)
 
     def test_subset_beta_values(self, beta_mock):
@@ -159,31 +168,6 @@ class TestPower:
         )
         assert str(exc_info.value) == exp_err_msg
 
-    def test_alpha_power_non_categorical(self, alpha_mock):
-        with pytest.raises(exc.NonCategoricalColumnError) as exc_info:
-            alpha_mock.power_analysis(
-                "year_diagnosed",
-                alpha=0.05,
-                power=0.8
-            )
-        exp_err_msg = (
-            "Column must be categorical (dtype object). 'year_diagnosed' "
-            "is of type int64."
-        )
-        assert str(exc_info.value) == exp_err_msg
-
-    def test_alpha_power_only_one_cat(self, alpha_mock):
-        with pytest.raises(exc.OnlyOneCategoryError) as exc_info:
-            alpha_mock.power_analysis(
-                "env_biome",
-                alpha=0.05,
-                power=0.8
-            )
-        exp_err_msg = (
-            "Column env_biome has only one value: 'urban biome'."
-        )
-        assert str(exc_info.value) == exp_err_msg
-
     def test_alpha_power_f(self, alpha_mock, monkeypatch):
         # Monkey patch Cohen's f calculation directly in diversity_handler
         #     instead of in _utils. Doesn't really make sense that it has
@@ -215,23 +199,6 @@ class TestPower:
 
 
 class TestEffectSize:
-    def test_non_categorical(self, alpha_mock):
-        with pytest.raises(exc.NonCategoricalColumnError) as exc_info:
-            alpha_mock.calculate_effect_size("year_diagnosed")
-        exp_err_msg = (
-            "Column must be categorical (dtype object). 'year_diagnosed' "
-            "is of type int64."
-        )
-        assert str(exc_info.value) == exp_err_msg
-
-    def test_only_one_category(self, alpha_mock):
-        with pytest.raises(exc.OnlyOneCategoryError) as exc_info:
-            alpha_mock.calculate_effect_size("env_biome")
-        exp_err_msg = (
-            "Column env_biome has only one value: 'urban biome'."
-        )
-        assert str(exc_info.value) == exp_err_msg
-
     def test_difference(self, alpha_mock):
         calc_effect_size = alpha_mock.calculate_effect_size(
             "classification",

--- a/evident/tests/test_effect_size.py
+++ b/evident/tests/test_effect_size.py
@@ -134,7 +134,7 @@ def test_nan_in_cols():
 
     faith_vals = pd.Series([1, 3, 4, 5, 6, 6])
     faith_vals.index = df.index
-    adh = AlphaDiversityHandler(faith_vals, df)
+    adh = AlphaDiversityHandler(faith_vals, df, min_count_per_level=1)
     assert not np.isnan(adh.calculate_effect_size("col1").effect_size)
     assert not np.isnan(adh.calculate_effect_size("col2").effect_size)
 
@@ -148,11 +148,8 @@ def test_nan_in_cols_one_one_cat():
 
     faith_vals = pd.Series([1, 3, 4, 5, 6, 6])
     faith_vals.index = df.index
-    adh = AlphaDiversityHandler(faith_vals, df)
+    adh = AlphaDiversityHandler(faith_vals, df, min_count_per_level=1)
     assert not np.isnan(adh.calculate_effect_size("col1").effect_size)
 
-    with pytest.raises(exc.OnlyOneCategoryError) as exc_info:
+    with pytest.raises(KeyError) as exc_info:
         adh.calculate_effect_size("col2")
-
-    exp_err_msg = "Column col2 has only one value: 'c'."
-    assert str(exc_info.value) == exp_err_msg

--- a/evident/tests/test_effect_size.py
+++ b/evident/tests/test_effect_size.py
@@ -4,7 +4,6 @@ import pytest
 
 from evident import AlphaDiversityHandler
 from evident import effect_size as expl
-from evident import _exceptions as exc
 
 
 @pytest.mark.parametrize("mock", ["alpha_mock", "beta_mock"])
@@ -151,5 +150,5 @@ def test_nan_in_cols_one_one_cat():
     adh = AlphaDiversityHandler(faith_vals, df, min_count_per_level=1)
     assert not np.isnan(adh.calculate_effect_size("col1").effect_size)
 
-    with pytest.raises(KeyError) as exc_info:
+    with pytest.raises(KeyError):
         adh.calculate_effect_size("col2")

--- a/evident/tests/test_interactive.py
+++ b/evident/tests/test_interactive.py
@@ -10,14 +10,10 @@ from evident.interactive import create_bokeh_app
 
 @pytest.mark.parametrize("mock", ["alpha_mock", "beta_mock"])
 def test_interactive(mock, request, tmpdir):
-    dh = request.getfixturevalue(mock)
-    na_vals = ["missing: not provided", "not applicable"]
-    dh.metadata = dh.metadata.replace({x: np.nan for x in na_vals})
-    dh.metadata = dh.metadata.dropna(axis=1, how="all")
-    dh.metadata = dh.metadata.dropna(axis=0, how="any")
-
     outdir = f"{tmpdir}/{mock}"
+
     with pytest.warns(UserWarning) as warn_info:
+        dh = request.getfixturevalue(mock)
         create_bokeh_app(dh, f"{outdir}")
 
     exp_msg_1 = (
@@ -25,7 +21,7 @@ def test_interactive(mock, request, tmpdir):
         "one level or too many. Use the max_levels_per_category "
         "argument to modify this threshold."
     )
-    assert warn_info[0].message.args[0] == exp_msg_1
+    assert exp_msg_1 in warn_info[0].message.args[0]
 
     files = glob.glob(f"{outdir}/**/*", recursive=True)
     files = set([os.path.relpath(x, start=outdir) for x in files])
@@ -55,47 +51,3 @@ def test_interactive(mock, request, tmpdir):
         "classification"
     ]
     assert (exp_cols == md.columns).all()
-
-
-@pytest.mark.parametrize("mock", ["alpha_mock", "beta_mock"])
-def test_interactive_warnings(mock, request, tmpdir):
-    dh = request.getfixturevalue(mock)
-    na_vals = ["missing: not provided", "not applicable"]
-    dh.metadata = dh.metadata.replace({x: np.nan for x in na_vals})
-    dh.metadata = dh.metadata.dropna(axis=1, how="all")
-    dh.metadata = dh.metadata.dropna(axis=0, how="any")
-
-    col_1 = ["A", "A", "A", "C", "C"] + ["B"] * (dh.metadata.shape[0] - 5)
-    dh.metadata["col_1"] = col_1
-
-    outdir = f"{tmpdir}/{mock}"
-    with pytest.warns(UserWarning) as warn_info:
-        create_bokeh_app(dh, f"{outdir}")
-
-    exp_msg_1 = (
-        "Some categories have been dropped because they had either only "
-        "one level or too many. Use the max_levels_per_category "
-        "argument to modify this threshold."
-    )
-    exp_msg_2 = (
-        "Some categorical levels have been dropped because they "
-        "did not have enough samples. Use the min_count_per_level "
-        "argument to modify this threshold."
-    )
-    assert warn_info[0].message.args[0] == exp_msg_1
-    assert warn_info[1].message.args[0] == exp_msg_2
-
-    md = pd.read_table(os.path.join(outdir, "data/metadata.tsv"), sep="\t",
-                       index_col=0)
-    exp_cols = [
-        "cd_behavior",
-        "cd_location",
-        "cd_resection",
-        "ibd_subtype",
-        "perianal_disease",
-        "sex",
-        "classification",
-        "col_1"
-    ]
-    assert (exp_cols == md.columns).all()
-    assert set(md["col_1"].dropna().unique()) == {"A", "B"}

--- a/evident/tests/test_interactive.py
+++ b/evident/tests/test_interactive.py
@@ -1,7 +1,6 @@
 import os
 import glob
 
-import numpy as np
 import pandas as pd
 import pytest
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning
+    ignore::UserWarning


### PR DESCRIPTION
Previously we had parameters for `max_levels_per_category` and `min_count_per_level` only for the interactive visualization. Here, we move these parameters to the instantiation of `DiversityHandler` and warn users of dropped columns/levels.